### PR TITLE
-n --name flag added

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Windows, Mac and Linux tested!
 -e eventPath        | --event=eventPath             optional       Path to .json file contains event object
 -c contextPath      | --context=contextPath         optional       Path to .json file contains context object
 -t seconds          | --timeout=seconds             optional       Force quit Lambda function after XX seconds
+-n name             | --name=name                   optional       Property name for the exported Lambda function in main file
 ```
 
 ## Usage

--- a/lambda-local.js
+++ b/lambda-local.js
@@ -135,6 +135,15 @@ var exitTimer = setTimeout(function() {
 
 var getHandler = function(filename) {
     var exported = require(filename);
+
+    if (args.n || args.name) {
+        var fName = args.n || args.name;
+        if (exported.hasOwnProperty(fName) && typeof(exported[fName]) === 'function') {
+            return exported[fName];
+        }
+        console.log('Cannot resolve given function ' + name + '.' + fName);
+        process.exit(1);
+    }
     for (var property in exported) {
         if (exported.hasOwnProperty(property) && typeof(exported[property]) === 'function') {
             return exported[property];


### PR DESCRIPTION
This is an optional parameter you can use to specify which function you want to test with aws-lambda-local.

My use case is that, sometimes I export other functions in the same module (even multiple handlers) for different purposes, so being able to specify which function I want to run would be helpful here.

This new flag is completely optional and it doesnt change the previous behaviour when omitted

```
// handler.js
module.exports = {
 otherFunction: function() { // whatever otherFunction does },
 handler: function(event, context) { // whatever handler does },
};
```

PS: If you agree to merge this PR, I can also update the README example with the -n flag if needed.